### PR TITLE
catch runtime exception for DvXplorer Mini

### DIFF
--- a/src/device/dvxplorer.cpp
+++ b/src/device/dvxplorer.cpp
@@ -22,6 +22,7 @@
 
 namespace libcaer_driver
 {
+static rclcpp::Logger get_logger() { return (rclcpp::get_logger("device")); }
 //
 // The following definitions are used for a more compact notation when building the
 // parameter list.
@@ -73,6 +74,13 @@ static std::shared_ptr<Parameters> make_dvxplorer_parameters()
 
 DvXplorer::DvXplorer() { parameters_ = make_dvxplorer_parameters(); }
 
-void DvXplorer::resetTimeStamps() { device_->configSet(DVX_MUX, DVX_MUX_TIMESTAMP_RESET, 1); }
-
+void DvXplorer::resetTimeStamps()
+{
+  try {
+    device_->configSet(DVX_MUX, DVX_MUX_TIMESTAMP_RESET, 1);
+  } catch (const std::runtime_error &) {
+    // resetting timestamp throws error for DvXplorer Mini
+    LOG_WARN("Could not reset time stamps.");
+  }
+}
 }  // namespace libcaer_driver


### PR DESCRIPTION
The libusb device descriptor reports a MIPI device for the DvXplorer Mini. Hence, setting configs for `modAddr == DVX_MUX` will fail. The try-catch block will handle this case and will allow the DvXplorer Mini to operate normally.

Also see the corresponding lines in [`libcaer`](https://github.com/ros-event-camera/libcaer/blob/264c576e132057360caaa7b75c19100287dec64e/src/dvxplorer.c#L567C3-L569C5).

Maybe it might be even better to report back if the timestamps could be reset. But this would require changes to the device interface.

But besides from this issue, the mini version of the DvXplorer seems to run fine with the `libcamera_driver`.