### PR TITLE
support for composable recording under Jazzy+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ install(TARGETS
   driver
   DESTINATION lib)
 
+install(PROGRAMS
+  src/stop_recording.py
+  DESTINATION lib/${PROJECT_NAME}/)
+
 install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ ros2 launch libcaer_driver driver_node.launch.py device_type:=davis
 ```
 Edit ``driver_node.launch.py`` to set various parameters, or use ``rqt_reconfigure`` to modify the parameters on the fly.
 
+### Recording on ROS2 Humble and older
+
 For efficient recording of the events you need to run the
 driver and the recorder in the same address space using ROS2 composable
 nodes. For this you will need to install the
@@ -117,6 +119,19 @@ ros2 service call /start_recording std_srvs/srv/Trigger
 ```
 To stop the recording you have to kill (Ctrl-C) the recording driver.
 
+### Recording on ROS2 Jazzy and newer
+
+With Jazzy the rosbag framework got upgraded to provide composable recording. First launch
+the driver as a composable node, then load the recorder into the same container with
+the ``start_recording.launch.py`` script and unload it with ``stop_recording.py``:
+```
+ros2 launch libcaer_driver driver_composition.launch.py
+ros2 launch libcaer_driver start_recording.launch.py
+ros2 run libcaer_driver stop_recording.py
+```
+
+
+### Visualizing the events
 To visualize the events, run a ``renderer`` node from the
 [event_camera_renderer](https://github.com/ros-event-camera/event_camera_renderer) package:
 ```

--- a/launch/driver_composition.launch.py
+++ b/launch/driver_composition.launch.py
@@ -1,0 +1,83 @@
+# -----------------------------------------------------------------------------
+# Copyright 2023 Bernd Pfrommer <bernd.pfrommer@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+import launch
+from launch.actions import DeclareLaunchArgument as LaunchArg
+from launch.actions import OpaqueFunction
+from launch.substitutions import LaunchConfiguration as LaunchConfig
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def launch_setup(context, *args, **kwargs):
+    """Create composed driver + recorder node."""
+    container = ComposableNodeContainer(
+        name="libcaer_driver_container",
+        namespace="",
+        package="rclcpp_components",
+        executable="component_container",
+        # prefix=["xterm -e gdb -ex run --args"],
+        composable_node_descriptions=[
+            ComposableNode(
+                package="libcaer_driver",
+                plugin="libcaer_driver::Driver",
+                name=LaunchConfig("camera_name"),
+                parameters=[
+                    {
+                        "device_type": LaunchConfig("device_type"),
+                        "device_id": 1,
+                        "encoding": "libcaer_cmp",
+                        "statistics_print_interval": 2.0,
+                        "event_message_time_threshold": 1.0e-3,
+                        "aps_exposure": 2543,
+                        "aps_frame_interval": 200000,
+                        "aps_enabled": False,
+                        "dvs_enabled": True,
+                        "aps_frame_mode": 1,
+                        "auto_exposure_enabled": False,
+                        "auto_exposure_illumination": 127.0,
+                    },
+                ],
+                extra_arguments=[{"use_intra_process_comms": True}],
+            ),
+        ],
+        output="screen",
+    )
+    return [container]
+
+
+def generate_launch_description():
+    """Create simple node by calling opaque function."""
+    return launch.LaunchDescription(
+        [
+            LaunchArg(
+                "camera_name", default_value=["event_camera"], description="camera name"
+            ),
+            LaunchArg(
+                "device_type",
+                default_value=["davis"],
+                description="device type (davis, dvxplorer...)",
+            ),
+            LaunchArg("bag", default_value=[""], description="name of output bag"),
+            LaunchArg(
+                "bag_prefix",
+                default_value=["events_"],
+                description="prefix of output bag",
+            ),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/launch/start_recording.launch.py
+++ b/launch/start_recording.launch.py
@@ -1,0 +1,73 @@
+# -----------------------------------------------------------------------------
+# Copyright 2025 Bernd Pfrommer <bernd.pfrommer@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+from datetime import datetime
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument as LaunchArg
+from launch.actions import OpaqueFunction
+from launch.substitutions import LaunchConfiguration as LaunchConfig
+from launch_ros.actions import LoadComposableNodes
+from launch_ros.descriptions import ComposableNode
+
+
+def make_name(prefix, context):
+    now = datetime.now()
+    return prefix.perform(context) + now.strftime('%Y_%m_%d-%H_%M_%S')
+
+
+def launch_setup(context, *args, **kwargs):
+    launch_action = LoadComposableNodes(
+        target_container=LaunchConfig('container_name'),
+        composable_node_descriptions=[
+            ComposableNode(
+                package='rosbag2_transport',
+                plugin='rosbag2_transport::Recorder',
+                name='recorder',
+                parameters=[
+                    {
+                        'record.topics': ['/event_camera/events'],
+                        # 'record.topics': ['/event_camera/events',
+                        #                   '/event_camera/image_raw'],
+                        'record.start_paused': False,
+                        'storage.uri': make_name(LaunchConfig('bag_prefix'), context),
+                    }
+                ],
+                extra_arguments=[{'use_intra_process_comms': True}],
+            ),
+        ],
+    )
+    return [launch_action]
+
+
+def generate_launch_description():
+    """Create composable node by calling opaque function."""
+    return LaunchDescription(
+        [
+            LaunchArg(
+                'container_name',
+                default_value=['libcaer_driver_container'],
+                description='name of camera driver container node',
+            ),
+            LaunchArg(
+                'bag_prefix',
+                default_value=['events_'],
+                description='prefix of rosbag',
+            ),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/src/stop_recording.py
+++ b/src/stop_recording.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Copyright 2024 Bernd Pfrommer <bernd.pfrommer@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import subprocess
+
+import rclpy
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    cname = '/libcaer_driver_container'
+    output = subprocess.run(['ros2', 'component', 'list', cname], stdout=subprocess.PIPE)
+    lines = output.stdout.decode('utf-8').splitlines()
+    stopped = False
+    for line in lines:
+        a = line.split()
+        if a[1] == '/recorder':
+            output = subprocess.run(
+                ['ros2', 'component', 'unload', cname, f'{a[0]}'], stdout=subprocess.PIPE
+            )
+            stopped = True
+    if stopped:
+        print('recording stopped!')
+    else:
+        print('WARNING: recording not stopped because none was running!')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR provides launch scripts and a python program to unload the composable recorder under Jazzy and later versions of ROS2.
